### PR TITLE
[feature] allow namespacing for date service to work in tests

### DIFF
--- a/addon-test-support/setup-fake-date-service.js
+++ b/addon-test-support/setup-fake-date-service.js
@@ -8,5 +8,6 @@ import FakeDateService from './date';
 export default function setupFakeDateService(hooks = self) {
   hooks.beforeEach(function() {
     this.owner.register('service:date', FakeDateService);
+    this.owner.register('service:ember-date-service@date', FakeDateService);
   });
 }

--- a/tests/unit/setup-fake-date-service-test.js
+++ b/tests/unit/setup-fake-date-service-test.js
@@ -11,7 +11,19 @@ module('Unit | Setup | setupFakeDateService', function(hooks) {
 
     assert.equal(typeof fakeDateService.setNow, 'function');
   });
+
+
+  test('it sets up the fake namespaced date service', function(assert) {
+    const namespacedService = this.owner.lookup('service:ember-date-service@date');
+
+    const date = new Date();
+
+    namespacedService.setNow(date)
+
+    assert.equal(namespacedService.now(), date.getTime());
+  });
 });
+
 
 module('Unit | setupFakeDateService not used', function(hooks) {
   setupTest(hooks);


### PR DESCRIPTION
# Reasoning 

In larger projects Namespacing modules allow clear ownership right now we use 

`this.owner.lookup('service:module@service-name')`

# Fix

Registering both would allow us to use the namespace for this module

`this.owner.lookup('service:ember-date-service@date')` and `this.owner.lookup('service:date')` would be valid lookups 