### PR TITLE
task: Enable passing Date instance to setNow

### DIFF
--- a/addon-test-support/date.js
+++ b/addon-test-support/date.js
@@ -1,4 +1,4 @@
-import DateService from 'ember-date-service/services/date';
+import DateService from "ember-date-service/services/date";
 
 /**
  * @class FakeDateService
@@ -22,7 +22,9 @@ export default DateService.extend({
   },
 
   setNow(date = Date.now()) {
-    this._now = date;
+    this._now = date instanceof Date ? date.getTime() : date;
+
+    return this._now;
   },
 
   reset() {

--- a/tests/unit/fake-date-service-test.js
+++ b/tests/unit/fake-date-service-test.js
@@ -23,6 +23,14 @@ module('Unit | Service | fake date', function(hooks) {
     assert.equal(this.fakeService.now(), now);
   });
 
+  test('it can set date to specific date via Date object', function(assert) {
+    let date = new Date();
+    let now = this.fakeService.setNow(date);
+
+    assert.equal(typeof this.fakeService.now(), 'number');
+    assert.equal(this.fakeService.now(), now);
+  });
+
   test('it can reset date that was previously set', function(assert) {
     let done = assert.async();
     let now = Date.now();


### PR DESCRIPTION
Allows for passing `Date` instance to `setNow`, which will automatically convert to a number via `getTime`.