### PR TITLE
Convert to native classes

### DIFF
--- a/addon-test-support/date.js
+++ b/addon-test-support/date.js
@@ -1,4 +1,4 @@
-import DateService from "ember-date-service/services/date";
+import DateService from 'ember-date-service/services/date';
 
 /**
  * @class FakeDateService
@@ -6,28 +6,28 @@ import DateService from "ember-date-service/services/date";
  * Extends the provided internal DateService, allowing you to override
  * Date.now() and Date.UTC() without modifying the native Date object.
  */
-export default DateService.extend({
-  init() {
-    this._super(...arguments);
+export default class FakeDateService extends DateService {
+  constructor() {
+    super(...arguments);
 
     this._now = null;
-  },
+  }
 
   now() {
     if (this._now) {
       return this._now;
     }
 
-    return this._super(...arguments);
-  },
+    return super.now(...arguments);
+  }
 
   setNow(date = Date.now()) {
     this._now = date instanceof Date ? date.getTime() : date;
 
     return this._now;
-  },
+  }
 
   reset() {
     this._now = null;
-  },
-});
+  }
+}

--- a/addon/services/date.js
+++ b/addon/services/date.js
@@ -10,16 +10,16 @@ import Service from '@ember/service';
  * which allows you to override dates with static values without having to
  * modify the native Date object.
  */
-export default Service.extend({
+export default class DateService extends Service {
   now() {
     return Date.now();
-  },
+  }
 
   UTC(...args) {
     return new Date(Date.UTC(...args));
-  },
+  }
 
   parse(dateString) {
     return Date.parse(dateString);
-  },
-});
+  }
+}


### PR DESCRIPTION
Updating this to Octane idioms allows us to remove one more bit of Ember Classic code in the ecosystem!